### PR TITLE
Fixes Text Editor selection

### DIFF
--- a/src/Registry.pkgdef
+++ b/src/Registry.pkgdef
@@ -2,7 +2,7 @@
 ;--------------------------------------------------------;
 [$RootKey$\Languages\File Extensions\.svg]
 @="{9bbfd173-9770-47dc-b191-651b7ff493cd}"
-[$RootKey$\Editors\{40d31677-cbc0-4297-a9ef-89d907823a98}\Extensions]
+[$RootKey$\Editors\{fa3cd31e-987b-443a-9b81-186104e8dac1}\Extensions]
 "svg"=dword:32
 
 


### PR DESCRIPTION
Fixes #14 changing the default editor for the .svg extension to XML (Text) Editor, instead of HTML editor.

Maybe it was the same problem in #1